### PR TITLE
Allow dash in PQ redis host

### DIFF
--- a/src/Setup/ConfigOptionsList.php
+++ b/src/Setup/ConfigOptionsList.php
@@ -139,7 +139,7 @@ class ConfigOptionsList implements ConfigOptionsListInterface
     {
         $errors = [];
         if (isset($options[self::INPUT_KEY_PQ_HOST]) &&
-            !preg_match('/^[a-zA-Z0-9_\.]+$/', $options[self::INPUT_KEY_PQ_HOST])) {
+            !preg_match('/^[a-zA-Z0-9\-_\.]+$/', $options[self::INPUT_KEY_PQ_HOST])) {
             $errors[] = "Invalid persisted query redis host";
         }
         if (isset($options[self::INPUT_KEY_PQ_PORT]) &&


### PR DESCRIPTION
Redis host path can be a FQDN and the current regex does not allow addresses containing a dash.
Example: redis-host.provider-example.local