### PR TITLE
Add require for ext-redis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "OSL-3.0"
     ],
     "require": {
+        "ext-redis": "*",
         "magento/framework": "*",
         "magento/module-cache-invalidate": "*",
         "magento/module-page-cache": "*",


### PR DESCRIPTION
Since `\ScandiPWA\PersistedQuery\Plugin\PersistedQuery` injects `ScandiPWA\PersistedQuery\RedisClient`, rather than a caching oriented interface that can be exchanged for another caching type, this package has a hard dependency on Redis.