### PR TITLE
Remove hard dependency on magento/module-catalog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,11 @@
         "magento/module-cache-invalidate": "*",
         "magento/module-page-cache": "*",
         "magento/module-store": "*",
-        "magento/module-catalog": "*",
         "magento/module-graph-ql": "^100.3",
         "colinmollenhour/credis": "^1.10"
+    },
+    "suggest": {
+        "magento/module-catalog": "To invalidate persisted_query cache after full reindex"
     },
     "autoload": {
         "files": [

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -16,7 +16,6 @@
             <module name="Magento_CacheInvalidate"/>
             <module name="Magento_PageCache"/>
             <module name="Magento_Store"/>
-            <module name="Magento_Catalog"/>
             <module name="Magento_GraphQl"/>
         </sequence>
     </module>


### PR DESCRIPTION
This extension does not truly have a hard dependency on `magento/module-catalog`. Nor does it require that `Magento_Catalog` be loaded before it during module load order. Reasoning behind these conclusions:

- The extension's only interaction with `magento/module-catalog` resides in the `\Scandiweb\PersistedQuery\Plugin\InvalidatePQCache` class object. This is class is only a plugin. Therefore, if someone where to ever actually accomplish disabling `Magento_Catalog` from their Magento application, this plugin would simply not ever execute. For this reason, it is not valid to define within `composer.json` a strict hard dependency on the module. However, I have added a `suggest` block, including `magento/module-catalog` to indicate that the module does interact with and have features that supplement `magento/module-catalog`.

- Regarding sequence load order: The module does not perform any overriding of configuration values setup from `Magento_Catalog` XML configuration. It is simply adding a configuration for a plugin to a `Magento_Catalog` class. Therefore in the end it doesn't actually matter if Magento_Catalog is loaded before, or after ScandiPWA_PersistedQuery. If for example, ScandiPWA_PersistedQuery were to define a `<preference>`, that overrides a `<preference>` setup by `Magento_Catalog`, then that would be an appropriate reason for having to ensure that `Magento_Catalog` is loaded first. In this scenario however, the XML configuration (which is unique to `ScandiPWA_PersistedQuery`) will be merged together into a combined result, and still included.