### PR TITLE
Use proxy class in CLI command argument

### DIFF
--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -33,4 +33,10 @@
     <type name="Magento\Catalog\Model\Indexer\Category\Product\Action\Full">
         <plugin name="invalidate_pq_response_cache" type="ScandiPWA\PersistedQuery\Plugin\InvalidatePQCache" />
     </type>
+    
+    <type name="ScandiPWA\PersistedQuery\Console\Command\PersistedQueryFlushCommand">
+        <arguments>
+            <argument name="query" xsi:type="object">ScandiPWA\PersistedQuery\Cache\Query\Proxy</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Prevents warning from occurring every time Magento instantiates PersistedQueryFlushCommand while env.php lacks cache/persisted_query configuration. (Magento will instantiate that class, every time it collects the available console commands, so a warning is currently being added to the logs when not really necessary, as the user did not really invoke this CLI command yet).