### PR TITLE
[4255] - searchig for + resulted in an error - fixed

### DIFF
--- a/src/Plugin/PersistedQuery.php
+++ b/src/Plugin/PersistedQuery.php
@@ -294,7 +294,7 @@ class PersistedQuery
         $variables = [];
 
         foreach ($args as $key => $value) {
-            $variables[$key] = json_decode(urldecode($value), true);
+            $variables[$key] = json_decode(rawurldecode($value), true);
         }
 
         return $variables;


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa/issues/4255

**Problem:**
* Typing + in the search bar and pressing enter resulted in an error
* This was happening because the backend was parsing + characters into blank spaces, which aren't searchable

**In this PR:**
* Replaced the urldecode method with rawurldecode, which is nearly identical in functionality other than the fact it doesn't parse the + characters 