### PR TITLE
Fix error with purge when doing cache:clean

### DIFF
--- a/src/Model/PurgeCache.php
+++ b/src/Model/PurgeCache.php
@@ -18,7 +18,7 @@ use Magento\Framework\Cache\InvalidateLogger;
 use Magento\PageCache\Model\Cache\Server;
 use Magento\PageCache\Model\Config;
 use Magento\Store\Model\ScopeInterface;
-use Zend\Uri\Uri;
+use Laminas\Uri\Uri;
 
 /**
  * Class PurgeCache
@@ -75,7 +75,10 @@ class PurgeCache extends CorePurgeCache
         $socketAdapter = $this->socketAdapterFactory->create();
         $servers = $this->cacheServer->getUris();
         $socketAdapter->setOptions(['timeout' => 10]);
-        $headers = ['X-Pool' => $poolTag];
+        $headers = [
+            'X-Pool' => $poolTag,
+            'X-Magento-Tags-Pattern' => '.*'
+        ];
 
         foreach ($servers as $server) {
             $headers['Host'] = $server->getHost();


### PR DESCRIPTION
This MR fixes the issue with the missing X-Magento-Tags-Patters header required when running with the latest magento cloud image (1bf045d9164d) 
https://hub.docker.com/r/magento/magento-cloud-docker-varnish

```
[2023-03-09 13:36:32] report.ERROR: Error flushing Varnish server. Host: "varnish". PURGE response code: 400 message: X-Magento-Tags-Pattern header required 
#0 /app/vendor/scandipwa/persisted-query/src/Model/PurgeCache.php(97): ScandiPWA\PersistedQuery\Model\PurgeCache->validateResponse(Object(Laminas\Uri\Uri), 'HTTP/1.1 400 X-...') 
#1 /app/vendor/scandipwa/persisted-query/src/Cache/Response.php(51): ScandiPWA\PersistedQuery\Model\PurgeCache->sendPoolPurgeRequest('persisted_q_res...') 
#2 /app/vendor/magento/framework/App/Cache/TypeList.php(195): ScandiPWA\PersistedQuery\Cache\Response->clean() 
#3 /app/vendor/magento/framework/App/Cache/Manager.php(91): Magento\Framework\App\Cache\TypeList->cleanType('persisted_query...') 
#4 /app/vendor/magento/module-backend/Console/Command/CacheCleanCommand.php(36): Magento\Framework\App\Cache\Manager->clean(Array) 
#5 /app/vendor/magento/module-backend/Console/Command/AbstractCacheTypeManageCommand.php(62): Magento\Backend\Console\Command\CacheCleanCommand->performAction(Array) 
#6 /app/vendor/symfony/console/Command/Command.php(255): Magento\Backend\Console\Command\AbstractCacheTypeManageCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#7 /app/vendor/magento/framework/Interception/Interceptor.php(58): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#8 /app/vendor/magento/framework/Interception/Interceptor.php(138): Magento\Backend\Console\Command\CacheCleanCommand\Interceptor->___callParent('run', Array) 
#9 /app/vendor/magento/framework/Interception/Interceptor.php(153): Magento\Backend\Console\Command\CacheCleanCommand\Interceptor->Magento\Framework\Interception\{closure}(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#10 /app/generated/code/Magento/Backend/Console/Command/CacheCleanCommand/Interceptor.php(77): Magento\Backend\Console\Command\CacheCleanCommand\Interceptor->___callPlugins('run', Array, Array)
 #11 /app/vendor/symfony/console/Application.php(1009): Magento\Backend\Console\Command\CacheCleanCommand\Interceptor->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#12 /app/vendor/symfony/console/Application.php(273): Symfony\Component\Console\Application->doRunCommand(Object(Magento\Backend\Console\Command\CacheCleanCommand\Interceptor), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#13 /app/vendor/magento/framework/Console/Cli.php(115): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#14 /app/vendor/symfony/console/Application.php(149): Magento\Framework\Console\Cli->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput)) 
#15 /app/bin/magento(23): Symfony\Component\Console\Application->run() #16 {main} [] []

In PurgeCache.php line 129:
                                                                                                                            
  Error flushing Varnish server. Host: "varnish". PURGE response code: 400 message: X-Magento-Tags-Pattern header required  
                                                                                                                            

cache:clean [--bootstrap BOOTSTRAP] [--] [<types>...]

