### PR TITLE
fix bug scandi pq flush on magento 2.4.6

### DIFF
--- a/src/Console/Command/PersistedQueryFlushCommand.php
+++ b/src/Console/Command/PersistedQueryFlushCommand.php
@@ -53,9 +53,13 @@ class PersistedQueryFlushCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($this->query->clean()) {
+        $success = $this->query->clean();
+        
+        if ($success) {
             $output->writeln('Persisted query caches flushed (redis + varnish)');
         }
-    }
+        
+        return $success ? 0 : 1; // Returns 0 for success, 1 for failure. Fixes scandipwa:pq:flush launch error on Magento 2.4.6 that says the return of an execute function must be of type int.
+    } 
     
 }


### PR DESCRIPTION
Solves the problem on Magento 2.4.6, when you run the bin/magento scandipwa:pq:flush command, where the execute function does not return an int value